### PR TITLE
Added AddMapping method override to accept a property as string instead of Expression<Func<T>>

### DIFF
--- a/ExcelDataReaderLinqToExcelAdapter/ExcelDataReaderLinqToExcelAdapter/src/LinqToExcelAdapter.cs
+++ b/ExcelDataReaderLinqToExcelAdapter/ExcelDataReaderLinqToExcelAdapter/src/LinqToExcelAdapter.cs
@@ -266,6 +266,36 @@ namespace ExcelDataReader
             }
 
             /// <summary>
+            /// Add mapping into the list of mapping items.
+            /// </summary>
+            /// <typeparam name="T">Type of class to map.</typeparam>
+            /// <param name="_mapping">Mapping function to map property's class to excel's column data.</param>
+            /// <param name="_strColumnName">Excel column's name where data is read.</param>
+            /// <param name="_funcConvertValue">Function to convert value if needed (if not directly convert from string to the target field type automatically).</param>
+            /// <param name="_bIsMandatory">If the mandatory is true, the binding will not work if this column is not found. false to work like LinqToExcel.</param>
+            public void AddMapping<T>(string _mapping, string _strColumnName, Func<string, object> _funcConvertValue = null, bool _bIsMandatory = false)
+            {
+                ListMapping.Add(new Mapping<T>(GetLambda<T>(_mapping), _strColumnName, _funcConvertValue, _bIsMandatory));
+            }
+
+            /// <summary>
+            /// Generate Expression for property of given type T
+            /// </summary>
+            private Expression<Func<T, object>> GetLambda<T>(string property)
+            {
+                var param = Expression.Parameter(typeof(T), "p");
+
+                Expression parent = Expression.Property(param, property);
+
+                if (!parent.Type.IsValueType)
+                {
+                    return Expression.Lambda<Func<T, object>>(parent, param);
+                }
+                var convert = Expression.Convert(parent, typeof(object));
+                return Expression.Lambda<Func<T, object>>(convert, param);
+            }
+			
+            /// <summary>
             /// Clear all the mapping.
             /// </summary>
             public void ClearMapping()


### PR DESCRIPTION
This method override is useful, if you need to be more flexible.

For example if you have a DTO class that has a A1 to A10 property and you don't want to map each property explicitly but instead use a for loop.

Or if (some of) the column names are identical to the property names of the DTO you can match them generically using this override.